### PR TITLE
Update to Plasmo v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 julia = "1"
+Plasmo = "0.3.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # PipsSolver.jl
 
-[![Build Status](https://travis-ci.com/jalving/MGPipsSolver.jl.svg?branch=master)](https://travis-ci.com/jalving/PipsSolver.jl)
-[![Codecov](https://codecov.io/gh/jalving/MGPipsSolver.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jalving/PipsSolver.jl)
 
 ## Overview
 PipsSolver.jl is a Julia interface to the [PIPS-NLP](https://github.com/Argonne-National-Laboratory/PIPS/tree/master/PIPS-NLP) nonlinear optimization solver.
@@ -9,10 +7,11 @@ Running the solver requires a working PIPS-NLP installation following the [instr
 The PipsSolver.jl package works with the graph-based algebraic modeling package [Plasmo.jl](https://github.com/zavalab/Plasmo.jl).
 
 ## Installation
-PipsSolver.jl can be installed using the following Julia Pkg command.
+PipsSolver.jl can be installed using the following Julia Pkg command. Note that currently, PipsSolver.jl only works with Plasmo.jl v0.3.0.
 
 ```julia
 using Pkg
+Pkg.add(Pkg.PackageSpec(name="Plasmo", version="0.3.0"))
 Pkg.add(PackageSpec(url="https://github.com/zavalab/PipsSolver.jl.git"))
 ```
 
@@ -20,7 +19,15 @@ Pkg.add(PackageSpec(url="https://github.com/zavalab/PipsSolver.jl.git"))
 ```julia
 using MPIClusterManagers # to import MPIManager
 using Distributed   # need to also import Distributed to use addprocs()
-using Plasmo
+
+#Setup worker environments
+#This will load the environment specified in this script's directory onto each worker
+@everywhere using Pkg
+@everywhere Pkg.activate((@__DIR__))
+
+#Load Plasmo and PipsSolver on every worker
+@everywhere using Plasmo
+@everywhere using PipsSolver
 
 graph = OptiGraph()
 
@@ -47,21 +54,12 @@ manager=MPIManager(np=2) # specify, number of mpi workers, launch cmd, etc.
 addprocs(manager)        # start mpi workers and add them as julia workers too.
 
 
-#Setup worker environments
-#NOTE: You will need to load your Julia environment onto each worker
-@everywhere using Pkg
-@everywhere Pkg.activate((@__DIR__))
+#Map julia workers to MPI ranks
+julia_workers = sort(collect(values(manager.mpi2j)))
+#Distribute the graph to workers. This creates the variable `pipsgraph` on each worker with an allocation of optinodes.
+remote_references = PipsSolver.distribute(graph,julia_workers,remote_name = :pipsgraph)
 
-#Load Plasmo and PipsSolver on every worker
-@everywhere using Plasmo
-@everywhere using PipsSolver
-
-
-julia_workers = sort(collect(values(manager.mpi2j))) # #Distribute the graph to workers
-
-remote_references = PipsSolver.distribute(graph,julia_workers,remote_name = :pipsgraph)  #create the variable pipsgraph on each worker
-
-# The remote modelgraphs can be queried if they are fetched from the other workers
+# The remote optigraphs can be queried if they are fetched from the other workers.  
 r1 = fetch(remote_references[1])
 r2 = fetch(remote_references[2])
 

--- a/src/PipsNlpInterface.jl
+++ b/src/PipsNlpInterface.jl
@@ -70,11 +70,11 @@ function getData(m::JuMP.Model)
     end
 end
 
-function pipsnlp_solve(graph::ModelGraph) #Assume graph variables and constraints are first stage
+function pipsnlp_solve(graph::OptiGraph) #Assume graph variables and constraints are first stage
 
     #TODO SUBGRAPHS with linkconstraints to subnodes
     if has_subgraphs(graph)
-        error("The PIPS-NLP does not yet support ModelGraphs with subgraphs.  You will need to aggregate the graph before calling pipsnlp_solve")
+        error("The PIPS-NLP does not yet support OptiGraphs with subgraphs.  You will need to aggregate the graph before calling pipsnlp_solve")
     end
 
     if has_NLlinkconstraints(graph)
@@ -711,7 +711,7 @@ function pipsnlp_solve(graph::ModelGraph) #Assume graph variables and constraint
         println("PIPS-NLP time:   ",  time() - t1, " (s)")
     end
 
-    #TODO.  Put solution onto actual ModelNode
+    #TODO.  Put solution onto actual OptiNode
     for (idx,node) in enumerate(modelList)  #set solution values for each model
         local_data = getData(node)
         if idx != 1


### PR DESCRIPTION
This updates the PipsSolver to be compatible with Plasmo v0.3.0.  There are a few more changes needed to make this compatible with v0.3.2, but it might be worth waiting until distributed modeling gets added to Plasmo.jl