### PR TITLE
fix solution population. initialize empty values to 0

### DIFF
--- a/src/PipsNlpInterface.jl
+++ b/src/PipsNlpInterface.jl
@@ -240,7 +240,7 @@ function pipsnlp_solve(graph::OptiGraph) #Assume graph variables and constraints
 
         nothing_values = isa.(jump_initval,Nothing)
         float_values = .!(nothing_values)
-        local_initval[nothing_values] .= 1  #set to 1 by default
+        local_initval[nothing_values] .= 0  #set to 1 by default
         local_initval[float_values] .= jump_initval[float_values]
         original_copy(local_initval,x0)
     end
@@ -730,7 +730,11 @@ function pipsnlp_solve(graph::OptiGraph) #Assume graph variables and constraints
         #node.ext[:colVal] = local_data.x_sol
         vars = MOI.get(node,MOI.ListOfVariableIndices())
         primals = OrderedDict(zip(vars,local_data.x_sol))
-        Plasmo._set_primals(JuMP.backend(node),primals)
+
+        id = graph.id
+        src = JuMP.backend(node)
+        src.primals[id] = primals
+        src.last_solution_id = id
 
         #TODO set duals
 


### PR DESCRIPTION
- This update sets uninitialized variables to zero, which should be consistent with Ipopt.  Originally we were setting initial values to 1.0, which was causing restoration phase errors for some problems.
- This PR also fixes a bug with setting primals on optinodes from PIPS-NLP since Plasmo no longer uses `Plasmo._set_primals`